### PR TITLE
Add Advance restart

### DIFF
--- a/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
+++ b/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
@@ -53,4 +53,12 @@
          pulsating and RGB control would set this config to 75. -->
     <integer name="config_deviceLightCapabilities">232</integer>
 
+    <!-- Defines the actions shown in advanced reboot submenu -->
+    <string-array name="config_restartActionsList">
+        <item>restart</item>
+        <item>restart_recovery</item>
+        <item>restart_bootloader</item>
+        <item>restart_fastboot</item>
+    </string-array>
+
 </resources>


### PR DESCRIPTION
i saw a message from someone that said why there is no Advance restart
because of that i made this change to add it

thanks for you work to keeping sdm660 devices alive